### PR TITLE
Require authentication for Character API

### DIFF
--- a/deploy/docker-compose.yaml
+++ b/deploy/docker-compose.yaml
@@ -5,6 +5,8 @@ services:
   authentication-db:
     image: postgres
     restart: always
+    ports:
+      - 5432:5432
     environment:
       POSTGRES_PASSWORD: this_is_a_public_password
 

--- a/src/AuthenticationApi/Config.cs
+++ b/src/AuthenticationApi/Config.cs
@@ -15,13 +15,12 @@ namespace AuthenticationApi
         public static IEnumerable<ApiScope> ApiScopes =>
             new ApiScope[]
             {
-                new ApiScope("characterapi"),
+                new ("characterapi"),
             };
 
         public static IEnumerable<Client> Clients(string gameUrl) =>
-            new Client[]
+            new []
             {
-                // interactive client using code flow + pkce
                 new Client
                 {
                     ClientId = "game",
@@ -31,10 +30,7 @@ namespace AuthenticationApi
                     RequirePkce = false,
 
                     RedirectUris = { gameUrl + "/api/auth/callback/identity-server4" },
-                    FrontChannelLogoutUri = gameUrl + "/signout-oidc",
-                    PostLogoutRedirectUris = { gameUrl + "/signout-callback-oidc" },
-
-                    AllowOfflineAccess = true,
+                    
                     AllowedScopes = { "openid", "profile", "characterapi" },
                     
                     RequireConsent = false

--- a/src/AuthenticationApi/appsettings.json
+++ b/src/AuthenticationApi/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Host=localhost;Username=postgres;Password=password;Database=authdb"
+    "DefaultConnection": "Host=localhost;Username=postgres;Password=this_is_a_public_password;Database=authdb"
   },
   "GameUrl": "http://localhost:3000"
 }

--- a/src/CharacterApi/CharacterApi.csproj
+++ b/src/CharacterApi/CharacterApi.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Grpc.AspNetCore" Version="2.33.1" />
     <PackageReference Include="Grpc.AspNetCore.Web" Version="2.33.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.9" />
   </ItemGroup>

--- a/src/CharacterApi/Controllers/HomeController.cs
+++ b/src/CharacterApi/Controllers/HomeController.cs
@@ -9,9 +9,9 @@ namespace CharacterApi.Controllers
         {
             var result = "<html>" +
                 "<head><title>HelloMoon Character API</title></head>" +
-                "<body><h1>HelloMoon Character API</h1><br /><table>";
-            foreach (var character in LocationService.Characters)
-                result += $"<tr><td>{character.Guid}</td><td>{character.X},{character.Y}</tr>";
+                "<body><h1>HelloMoon Character API</h1><br /><table cellspacing='10'>";
+            for (var i = 0; i < LocationService.Characters.Count; i++)
+                result += $"<tr><td>Character #{i+1}</td><td>{LocationService.Characters[i].X},{LocationService.Characters[i].Y}</tr>";
             result += "</table></body></html>";
 
             return Content(result, "text/html");

--- a/src/CharacterApi/Services/LocationService.cs
+++ b/src/CharacterApi/Services/LocationService.cs
@@ -6,10 +6,12 @@ using System.Linq;
 using System.Threading.Tasks;
 using CharacterApi.Models;
 using Grpc.Core;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.Logging;
 
 namespace CharacterApi.Services
 {
+    [Authorize]
     public class LocationService : Location.LocationBase
     {
         private static readonly ConcurrentDictionary<Guid, IList<IServerStreamWriter<LocationUpdateResponse>>> Subscriptions = new ();

--- a/src/CharacterApi/Startup.cs
+++ b/src/CharacterApi/Startup.cs
@@ -23,6 +23,15 @@ namespace CharacterApi
                     .AllowAnyHeader()
                     .WithExposedHeaders("Grpc-Status", "Grpc-Message", "Grpc-Encoding", "Grpc-Accept-Encoding");
             }));
+
+            services.AddAuthorization(options =>
+            {
+                options.AddPolicy("default", builder =>
+                {
+                    builder.RequireClaim("scope", "characterapi");
+                });
+                options.DefaultPolicy = options.GetPolicy("default") ?? options.DefaultPolicy;
+            });
             
             services.AddAuthentication(options =>
                 {
@@ -49,6 +58,7 @@ namespace CharacterApi
             app.UseCors();
 
             app.UseAuthentication();
+            app.UseAuthorization();
 
             app.UseEndpoints(endpoints =>
             {

--- a/src/CharacterApi/Startup.cs
+++ b/src/CharacterApi/Startup.cs
@@ -1,7 +1,7 @@
 ﻿using CharacterApi.Services;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
@@ -23,6 +23,16 @@ namespace CharacterApi
                     .AllowAnyHeader()
                     .WithExposedHeaders("Grpc-Status", "Grpc-Message", "Grpc-Encoding", "Grpc-Accept-Encoding");
             }));
+            
+            services.AddAuthentication(options =>
+                {
+                    options.DefaultScheme = JwtBearerDefaults.AuthenticationScheme;
+                })
+                .AddJwtBearer(JwtBearerDefaults.AuthenticationScheme, options =>
+                {
+                    options.MetadataAddress = "https://localhost:5000/.well-known/openid-configuration";
+                    options.TokenValidationParameters.ValidateAudience = false;
+                });
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -37,6 +47,8 @@ namespace CharacterApi
 
             app.UseGrpcWeb();
             app.UseCors();
+
+            app.UseAuthentication();
 
             app.UseEndpoints(endpoints =>
             {


### PR DESCRIPTION
Character API now requires a JWT token in HTTP header:
```
Authorization: Bearer {token}
````

Also only one character per user will now be rendered.